### PR TITLE
Fixed reserve button showing for books a user has reserved

### DIFF
--- a/src/main/client/src/dashBoard/bookList/reducer.js
+++ b/src/main/client/src/dashBoard/bookList/reducer.js
@@ -15,7 +15,7 @@ const getBooksAction = books => ({
 });
 
 // Action Creators
-export const getBooks = () => dispatch => {
+export const getBooks = () => (dispatch, getState) => {
   axios.get("/api/books").then(res => {
     const books = res.data.map(book => {
       return {
@@ -27,6 +27,7 @@ export const getBooks = () => dispatch => {
       };
     });
     dispatch(getBooksAction(books));
+    dispatch(checkAllBooks(getState().login.user));
   });
 };
 


### PR DESCRIPTION
Added a fix for the intermittent bug where a user could see a reserve button for a book they are borrowing. This issue was a race condition on page refresh.