### PR TITLE
added scheduled task to delete and reorder expired reservations

### DIFF
--- a/src/main/java/com/scottlogic/librarygradproject/Repositories/ReservationRepository.java
+++ b/src/main/java/com/scottlogic/librarygradproject/Repositories/ReservationRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -14,6 +15,9 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     @Query(value = "SELECT COUNT(*) FROM public.reservation WHERE book_id = :bookId", nativeQuery = true)
     long findLatestQueue(@Param("bookId") long bookId);
+
+    @Query(value = "SELECT * FROM public.reservation WHERE collect_by < :date", nativeQuery = true)
+    Stream<Reservation> findOverdueReservations(@Param("date") LocalDate date);
 
     List<Reservation> findAllByBookIdOrderByQueuePositionAsc(long bookId);
 

--- a/src/main/java/com/scottlogic/librarygradproject/Services/BorrowService.java
+++ b/src/main/java/com/scottlogic/librarygradproject/Services/BorrowService.java
@@ -98,10 +98,8 @@ public class BorrowService {
 
     @Transactional
     public void updateBorrowed(LocalDate currentDate) {
-        List<Long> borrowIds = new ArrayList<>();
         try (Stream<Borrow> borrows = borrowRepository.findOverdueBorrows(currentDate)) {
-            borrows.forEach(borrow -> borrowIds.add(borrow.getId()));
+            borrows.forEach(borrow -> bookReturned(borrow.getId()));
         }
-        borrowIds.forEach(id -> bookReturned(id));
     }
 }

--- a/src/main/java/com/scottlogic/librarygradproject/Services/ReservationService.java
+++ b/src/main/java/com/scottlogic/librarygradproject/Services/ReservationService.java
@@ -101,10 +101,8 @@ public class ReservationService {
 
     @Transactional
     public void updateReservations(LocalDate currentDate) {
-        List<Long> reservationIds = new ArrayList<>();
         try (Stream<Reservation> reservations = resRepo.findOverdueReservations(currentDate)) {
-            reservations.forEach(reservation -> reservationIds.add(reservation.getId()));
+            reservations.forEach(reservation -> delete(reservation.getId()));
         }
-        reservationIds.forEach(id -> delete(id));
     }
 }

--- a/src/main/java/com/scottlogic/librarygradproject/Services/ReservationService.java
+++ b/src/main/java/com/scottlogic/librarygradproject/Services/ReservationService.java
@@ -11,10 +11,14 @@ import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 
 import javax.swing.text.html.Option;
+import javax.transaction.Transactional;
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class ReservationService {
 
@@ -75,6 +79,9 @@ public class ReservationService {
                     .stream()
                     .map(res -> {
                         res.setQueuePosition(queuePosition.getAndIncrement());
+                        if (res.getQueuePosition() == 1) {
+                            res.setCollectBy(LocalDate.now().plusDays(3));
+                        }
                         return res;
                     }).collect(Collectors.toList());
             resRepo.saveAll(adjustedReservations);
@@ -90,5 +97,14 @@ public class ReservationService {
     public Reservation findOne(long reservationId) {
         Optional<Reservation> reservationToGet = resRepo.findById(reservationId);
         return reservationToGet.orElseThrow(() -> new ReservationNotFoundException(reservationId));
+    }
+
+    @Transactional
+    public void updateReservations(LocalDate currentDate) {
+        List<Long> reservationIds = new ArrayList<>();
+        try (Stream<Reservation> reservations = resRepo.findOverdueReservations(currentDate)) {
+            reservations.forEach(reservation -> reservationIds.add(reservation.getId()));
+        }
+        reservationIds.forEach(id -> delete(id));
     }
 }

--- a/src/main/java/com/scottlogic/librarygradproject/Tasks/ReservationUpdateTask.java
+++ b/src/main/java/com/scottlogic/librarygradproject/Tasks/ReservationUpdateTask.java
@@ -1,0 +1,28 @@
+package com.scottlogic.librarygradproject.Tasks;
+
+import com.scottlogic.librarygradproject.Services.ReservationService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+public class ReservationUpdateTask {
+
+    private final ReservationService reservationService;
+
+    @Bean
+    public TaskScheduler taskScheduler() {
+        return new ConcurrentTaskScheduler();
+    }
+
+    public ReservationUpdateTask(ReservationService reservationService) { this.reservationService = reservationService; }
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void checkExpiredReservations() {
+        reservationService.updateReservations(LocalDate.now());
+    }
+}


### PR DESCRIPTION
**BRIGRADS18-107**
- Created new task scheduler called reservationUpdateTask
- New scheduler checks at midnight everyday for any expired collection windows
- If there is an expired reservation, the reservation is deleted and remaining reservations for that book re-ordered
- The person at the top of the reservation queue is then given a new collect by date, which is in 3 days time from the present  